### PR TITLE
Updates to the Kaggle Badges in the `README` file

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ Question Answering (QA) in English has improved a lot in recent years with the a
     <li>
         Chaii Original -
         <a href="https://www.kaggle.com/c/chaii-hindi-and-tamil-question-answering/data">
-            <img alt="Kaggle" title="Click here to view the dataset" src="https://img.shields.io/badge/Kaggle-informational?style=flat-sqaure&logo=kaggle&logoColor=black&color=20BEFF">
+            <img alt="Kaggle" title="Click here to view the dataset" src="https://img.shields.io/badge/Kaggle%20Link-informational?style=flat-sqaure&logo=kaggle&logoColor=black&color=20BEFF">
         </a>
     </li>
     <li>
         Chaii Translated & Transliterated -
             <a href="https://www.kaggle.com/gokulkarthik/chaiitrans">
-            <img alt="Kaggle" title="Click here to view the dataset" src="https://img.shields.io/badge/Kaggle-informational?style=flat-sqaure&logo=kaggle&logoColor=black&color=20BEFF">
+            <img alt="Kaggle" title="Click here to view the dataset" src="https://img.shields.io/badge/Kaggle%20Link-informational?style=flat-sqaure&logo=kaggle&logoColor=black&color=20BEFF">
         </a>
     </li>
 </ul>

--- a/README.md
+++ b/README.md
@@ -52,13 +52,13 @@ Question Answering (QA) in English has improved a lot in recent years with the a
     <li>
         Chaii Original -
         <a href="https://www.kaggle.com/c/chaii-hindi-and-tamil-question-answering/data">
-            <img alt="Kaggle" src="https://img.shields.io/badge/Kaggle-informational?style=flat-sqaure&logo=kaggle&logoColor=black&color=20BEFF">
+            <img alt="Kaggle" title="Click here to view the dataset" src="https://img.shields.io/badge/Kaggle-informational?style=flat-sqaure&logo=kaggle&logoColor=black&color=20BEFF">
         </a>
     </li>
     <li>
         Chaii Translated & Transliterated -
             <a href="https://www.kaggle.com/gokulkarthik/chaiitrans">
-            <img alt="Kaggle" src="https://img.shields.io/badge/Kaggle-informational?style=flat-sqaure&logo=kaggle&logoColor=black&color=20BEFF">
+            <img alt="Kaggle" title="Click here to view the dataset" src="https://img.shields.io/badge/Kaggle-informational?style=flat-sqaure&logo=kaggle&logoColor=black&color=20BEFF">
         </a>
     </li>
 </ul>


### PR DESCRIPTION
Minor updates to the badges which link to the Kaggle datasets, along with a `<title>` attribute to inform the users.

P.S. The second [Kaggle link](https://www.kaggle.com/gokulkarthik/chaiitrans) is showing `Not Found`, so you might want to put in the updated link (or change the visibility settings for that dataset)